### PR TITLE
games-fps/gzdoom: Disabled LTO + Force Emake (#682)

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -17,6 +17,7 @@ dev-util/sccache *FLAGS+=-ffat-lto-objects # fails to link
 
 #Packages which cannot be built with LTO at all (previously was nolto.conf)
 dev-util/perf *FLAGS-=-flto*
+games-fps/gzdoom *FLAGS-=-flto* # Assertion `Class != nullptr' failed. SIGABRT
 app-emulation/libpod *FLAGS-=-flto*
 app-emulation/qemu *FLAGS-=-flto* *FLAGS+=-fno-strict-aliasing # required to compile qemu
 media-libs/alsa-lib *FLAGS-=-flto*
@@ -192,6 +193,7 @@ dev-python/pillow *FLAGS+='-fno-finite-math-only' # compiles fine but causes `im
 # END: -Ofast workarounds
 
 # BEGIN: Will not build with ninja
+games-fps/gzdoom CMAKE_MAKEFILE_GENERATOR=emake #"$@" || die "${nonfatal_args[@]}" "${*} failed"
 x11-misc/polybar CMAKE_MAKEFILE_GENERATOR=emake
 app-doc/doxygen CMAKE_MAKEFILE_GENERATOR=emake
 dev-lang/swi-prolog CMAKE_MAKEFILE_GENERATOR=emake


### PR DESCRIPTION
* games-fps/gzdoom: Disabled LTO + Force Emake

GZDoom doesn't build otherwise, unfortuanetly. According to (this issue)[https://github.com/InBetweenNames/gentooLTO/issues/524], it also doesn't work with ninja. Although I didn't test this for myself, I disabled it too just in case.

* games-fps/gzdoom: Disabled LTO + Force Emake

GZDoom doesn't build otherwise, unfortuanetly. According to (this issue)[https://github.com/InBetweenNames/gentooLTO/issues/524], it also doesn't work with ninja. Although I didn't test this for myself, I disabled it too just in case.

(Sorry about the second commit,  I made a spelling mistake in the original one.)

* games-fps/gzdoom: Added Reason For Workaround

Apologies, re-read the CONTRIBUTING.md section, and completely missed the fact that I needed to give the errors I got.

Title: <category>/<package>: <description>

Ensure that any added workarounds have a comment explaining the compilation error which requires it.
Any removed workarounds should be moved to the fixed section.
If an issue exists, please link it.
See .github/CONTRIBUTING.md for more information.
